### PR TITLE
Only write a file if type is a directory

### DIFF
--- a/vfftool/main.go
+++ b/vfftool/main.go
@@ -36,9 +36,8 @@ func main() {
 		fmt.Printf("- Name: \"%s\"\n- Type: directory\n", info.Name())
 	} else {
 		fmt.Printf("- Name: \"%s\"\n- Type: file\n- File size: %d\n", info.Name(), info.Size())
+		buffer := make([]byte, info.Size())
+		file.Read(buffer)
+		ioutil.WriteFile(info.Name(), buffer, 0777)
 	}
-
-	buffer := make([]byte, info.Size())
-	file.Read(buffer)
-	ioutil.WriteFile(info.Name(), buffer, 0777)
 }


### PR DESCRIPTION
Before it would write a blank executable file if type was a directory. Now it doesn't write anything.